### PR TITLE
Add simple slide-in animation for the tool-bar

### DIFF
--- a/styles/tool-bar.less
+++ b/styles/tool-bar.less
@@ -9,6 +9,7 @@
 .tool-bar {
   @button-margin-size: 2px;
   @button-border-size: 1px;
+  animation-duration: .3s;
   background-color: @base-background-color;
   border: 1px solid @base-border-color;
   color: @text-color;
@@ -167,5 +168,38 @@
     &.tool-bar-vertical .tool-bar-spacer {
       width: @size - 4;
     }
+
+    @keyframes slide-in-top {
+      from {margin-top: -@size;}
+      to {margin-top: 0;}
+    }
+
+    @keyframes slide-in-right {
+      from {margin-right: -@size;}
+      to {margin-right: 0;}
+    }
+
+    @keyframes slide-in-bottom {
+      from {margin-bottom: -@size;}
+      to {margin-bottom: 0;}
+    }
+
+    @keyframes slide-in-left {
+      from {margin-left: -@size;}
+      to {margin-left: 0;}
+    }
+  }
+
+  &.tool-bar-top {
+    animation-name: slide-in-top;
+  }
+  &.tool-bar-right {
+    animation-name: slide-in-right;
+  }
+  &.tool-bar-bottom {
+    animation-name: slide-in-bottom;
+  }
+  &.tool-bar-left {
+    animation-name: slide-in-left;
   }
 }


### PR DESCRIPTION
I used @keyframes to create the animations. The animations are based on 
margins with exact pixel values given the configured tool-bar icon size.

If the animations are created starting from, e.g. `margin-left: -100%` 
the toolbar is hidden, but the panel is not and so the animation does 
not work.

If the animations are created using the CSS `transform` property (I 
tried both `scale()` and `translate()`) you have the same problem.

I'm not sure how this animation works if the toolbar somehow has 
multiple rows/columns...